### PR TITLE
Purchase bonds

### DIFF
--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -410,6 +410,29 @@ contract Bond is
     }
 
     /// @inheritdoc IBond
+    function purchaseBond(uint256 amount) external {
+        if (amount > IERC20Metadata(paymentToken).allowance(msg.sender, address(this))) {
+            revert NotEnoughPaymentTokenAllowed();
+        }
+
+        if (amount > supplyRemaining) {
+            revert NotEnoughSupply();
+        }
+
+        // Reduce supply
+        supplyRemaining = supplyRemaining - amount;
+
+        // Transfers the payment token to the owner. Reverts if there is not enough
+        IERC20Metadata(paymentToken).safeTransferFrom(msg.sender, owner(), amount);
+
+        // Transfers the bonds to the buyer
+        _approve(address(this), msg.sender, amount);
+        transferFrom(address(this), msg.sender, amount);
+
+        emit BondPurchased(msg.sender, amount, supplyRemaining);
+    }
+
+    /// @inheritdoc IBond
     function collateralBalance()
         public
         view

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -57,6 +57,9 @@ contract Bond is
     /// @inheritdoc IBond
     uint256 public convertibleRatio;
 
+    /// @inheritdoc IBond
+    uint256 public supplyRemaining;
+
     /**
         @dev Confirms the Bond has not yet matured. This is used on the
             `convert` function because bond shares are convertible only before
@@ -115,6 +118,7 @@ contract Bond is
         collateralToken = _collateralToken;
         collateralRatio = _collateralRatio;
         convertibleRatio = _convertibleRatio;
+        supplyRemaining = maxSupply;
 
         _mint(bondOwner, maxSupply);
     }

--- a/contracts/Bond.sol
+++ b/contracts/Bond.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.9;
-
 import {IBond} from "./interfaces/IBond.sol";
 
 import {ERC20BurnableUpgradeable, IERC20MetadataUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
@@ -120,7 +119,7 @@ contract Bond is
         convertibleRatio = _convertibleRatio;
         supplyRemaining = maxSupply;
 
-        _mint(bondOwner, maxSupply);
+        _mint(address(this), maxSupply);
     }
 
     /// @inheritdoc IBond

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -168,13 +168,7 @@ interface IBond {
         @return The number of convertibleTokens per Bond.
     */
     function convertibleRatio() external view returns (uint256);
-
-     /**
-        @notice The number bonds remaining (unsold)
-        @return The number of bonds remaining
-    */
-    function supplyRemaining() external view returns (uint256);
-
+    
     /**
         @notice This one-time setup initiated by the BondFactory initializes the
             Bond with the given configuration.

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -161,6 +161,12 @@ interface IBond {
     */
     function convertibleRatio() external view returns (uint256);
 
+     /**
+        @notice The number bonds remaining (unsold)
+        @return The number of bonds remaining
+    */
+    function supplyRemaining() external view returns (uint256);
+
     /**
         @notice This one-time setup initiated by the BondFactory initializes the
             Bond with the given configuration.

--- a/contracts/interfaces/IBond.sol
+++ b/contracts/interfaces/IBond.sol
@@ -28,6 +28,12 @@ interface IBond {
     /// @notice Attempted to withdraw more collateral than available.
     error NotEnoughCollateral();
 
+    /// @notice Attempted purchase bonds without enough paymentToken allowed
+    error NotEnoughPaymentTokenAllowed();
+
+    /// @notice Attempted purchase more bonds than the supply
+    error NotEnoughSupply();
+
     /**
         @notice Emitted when bond shares are converted by a Bond holder.
         @param from The address converting their tokens.
@@ -110,6 +116,8 @@ interface IBond {
         IERC20Metadata token,
         uint256 amount
     );
+
+    event BondPurchased(address buyer, uint256 amount, uint256 supplyRemaining);
 
     /**
         @notice The amount of paymentTokens required to fully pay the contract.
@@ -344,6 +352,13 @@ interface IBond {
         external
         view
         returns (uint256 paymentTokens);
+
+     /**
+        @notice Directly purchases the bond from the contract. Bonds can only purchased
+        using the payment token specified in the contract. 
+        @param amount The amount to purchase
+    */
+    function purchaseBond(uint256 amount) external;
 
     /**
         @notice The Bond holder can burn bond shares in return for their portion

--- a/docs/Bond.md
+++ b/docs/Bond.md
@@ -27,6 +27,28 @@ A custom ERC20 token that can be used to issue bonds.The contract handles issuan
       </tr>
 </table>
 
+### BondPurchased
+
+
+
+
+
+
+<table>
+  <tr>
+    <td>address </td>
+    <td>buyer</td>
+      </tr>
+  <tr>
+    <td>uint256 </td>
+    <td>amount</td>
+      </tr>
+  <tr>
+    <td>uint256 </td>
+    <td>supplyRemaining</td>
+      </tr>
+</table>
+
 ### CollateralWithdraw
 
 Emitted when collateral is withdrawn.
@@ -258,6 +280,16 @@ Emitted when a token is swept by the contract owner.
 
 ### NotEnoughCollateral
 * Attempted to withdraw more collateral than available.
+
+
+
+### NotEnoughPaymentTokenAllowed
+* Attempted purchase bonds without enough paymentToken allowed
+
+
+
+### NotEnoughSupply
+* Attempted purchase more bonds than the supply
 
 
 
@@ -988,6 +1020,26 @@ The number of excess paymentTokens that the owner would be able to withdraw from
     The number of paymentTokens that would be withdrawn.    </td>
       </tr>
 </table>
+
+### purchaseBond
+
+```solidity
+function purchaseBond(uint256 amount) external nonpayable
+```
+
+Directly purchases the bond from the contract. Bonds can only purchased using the payment token specified in the contract. 
+
+#### Parameters
+
+<table>
+  <tr>
+    <td>uint256 </td>
+    <td>amount</td>
+        <td>
+    The amount to purchase    </td>
+      </tr>
+</table>
+
 
 ### redeem
 

--- a/docs/interfaces/IBond.md
+++ b/docs/interfaces/IBond.md
@@ -5,6 +5,28 @@
 
 ## Events
 
+### BondPurchased
+
+
+
+
+
+
+<table>
+  <tr>
+    <td>address </td>
+    <td>buyer</td>
+      </tr>
+  <tr>
+    <td>uint256 </td>
+    <td>amount</td>
+      </tr>
+  <tr>
+    <td>uint256 </td>
+    <td>supplyRemaining</td>
+      </tr>
+</table>
+
 ### CollateralWithdraw
 
 Emitted when collateral is withdrawn.
@@ -230,6 +252,16 @@ Emitted when a token is swept by the contract owner.
 
 ### NotEnoughCollateral
 * Attempted to withdraw more collateral than available.
+
+
+
+### NotEnoughPaymentTokenAllowed
+* Attempted purchase bonds without enough paymentToken allowed
+
+
+
+### NotEnoughSupply
+* Attempted purchase more bonds than the supply
 
 
 
@@ -712,6 +744,26 @@ The number of excess paymentTokens that the owner would be able to withdraw from
     The number of paymentTokens that would be withdrawn.    </td>
       </tr>
 </table>
+
+### purchaseBond
+
+```solidity
+function purchaseBond(uint256 amount) external nonpayable
+```
+
+Directly purchases the bond from the contract. Bonds can only purchased using the payment token specified in the contract. 
+
+#### Parameters
+
+<table>
+  <tr>
+    <td>uint256 </td>
+    <td>amount</td>
+        <td>
+    The amount to purchase    </td>
+      </tr>
+</table>
+
 
 ### redeem
 

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -1131,7 +1131,7 @@ describe("Bond", () => {
             config = bondWithTokens.nonConvertible.config;
             await paymentToken.transfer(
               bondBuyer.address,
-              ethers.constants.Two
+              ethers.constants.One.mul(100) // Approve for 100
             );
           });
 
@@ -1158,15 +1158,14 @@ describe("Bond", () => {
           });
 
           it("should transfer the bond to the buyer", async () => {
+            const seventeen = ethers.constants.One.mul(17);
             await paymentToken
               .connect(bondBuyer)
-              .approve(bond.address, ethers.constants.Two);
+              .approve(bond.address, seventeen);
 
-            await bond.connect(bondBuyer).purchaseBond(ethers.constants.One); // Just buying 1
+            await bond.connect(bondBuyer).purchaseBond(seventeen);
 
-            expect(await bond.balanceOf(bondBuyer.address)).to.eq(
-              ethers.constants.One
-            );
+            expect(await bond.balanceOf(bondBuyer.address)).to.eq(seventeen);
           });
         });
       });

--- a/test/Bond.spec.ts
+++ b/test/Bond.spec.ts
@@ -57,7 +57,8 @@ describe("Bond", () => {
   let factory: BondFactory;
   // this is a list of bonds created with the specific decimal tokens
   let bonds: BondWithTokens[];
-
+  // this is used for bond purchases
+  let bondBuyer: SignerWithAddress;
   // function to retrieve the bonds and tokens by decimal used
   const getBond = ({ decimals }: { decimals: number }) => {
     const foundBond = bonds.find((bond) => bond.decimals === decimals);
@@ -123,7 +124,8 @@ describe("Bond", () => {
                   collateralToken.address,
                   NonConvertibleBondConfig.collateralTokenAmount,
                   NonConvertibleBondConfig.convertibleTokenAmount,
-                  NonConvertibleBondConfig.maxSupply
+                  NonConvertibleBondConfig.maxSupply,
+                  "Uniswap"
                 )
               ),
               config: NonConvertibleBondConfig,
@@ -138,7 +140,8 @@ describe("Bond", () => {
                   collateralToken.address,
                   ConvertibleBondConfig.collateralTokenAmount,
                   ConvertibleBondConfig.convertibleTokenAmount,
-                  ConvertibleBondConfig.maxSupply
+                  ConvertibleBondConfig.maxSupply,
+                  "Uniswap"
                 )
               ),
               config: ConvertibleBondConfig,
@@ -153,7 +156,8 @@ describe("Bond", () => {
                   collateralToken.address,
                   UncollateralizedBondConfig.collateralTokenAmount,
                   UncollateralizedBondConfig.convertibleTokenAmount,
-                  UncollateralizedBondConfig.maxSupply
+                  UncollateralizedBondConfig.maxSupply,
+                  "Uniswap"
                 )
               ),
               config: UncollateralizedBondConfig,
@@ -168,7 +172,8 @@ describe("Bond", () => {
                   collateralToken.address,
                   MaliciousBondConfig.collateralTokenAmount,
                   MaliciousBondConfig.convertibleTokenAmount,
-                  MaliciousBondConfig.maxSupply
+                  MaliciousBondConfig.maxSupply,
+                  "Uniswap"
                 )
               ),
               config: MaliciousBondConfig,
@@ -186,7 +191,7 @@ describe("Bond", () => {
 
   beforeEach(async () => {
     // the signers are assigned here and used throughout the tests
-    [owner, bondHolder, attacker] = await ethers.getSigners();
+    [owner, bondHolder, attacker, bondBuyer] = await ethers.getSigners();
     // this is the bonds used in the getBond function
     ({ bonds, factory } = await loadFixture(fixture));
   });
@@ -262,7 +267,7 @@ describe("Bond", () => {
           });
 
           it("should have minted total supply of coins", async () => {
-            expect(await bond.balanceOf(owner.address)).to.be.equal(
+            expect(await bond.balanceOf(bond.address)).to.be.equal(
               config.maxSupply
             );
           });
@@ -317,7 +322,7 @@ describe("Bond", () => {
             expect(await bond.previewWithdrawExcessPayment()).to.equal(0);
           });
           it("should withdraw excess payment when bonds are redeemed", async () => {
-            const bonds = await bond.balanceOf(owner.address);
+            const bonds = await bond.balanceOf(bond.address);
             const fullPayment = await bond.amountUnpaid();
             await paymentToken.transfer(bond.address, fullPayment.mul(2));
             expect(await bond.previewWithdrawExcessPayment()).to.equal(
@@ -334,7 +339,7 @@ describe("Bond", () => {
             expect(await bond.previewWithdrawExcessPayment()).to.equal(0);
           });
           it("should have available overpayment when partially paid and all bonds are burnt", async () => {
-            const bonds = await bond.balanceOf(owner.address);
+            const bonds = await bond.balanceOf(bond.address);
             const halfPayment = (await bond.amountUnpaid()).div(2);
             await paymentToken.transfer(bond.address, halfPayment);
             expect(await bond.previewWithdrawExcessPayment()).to.equal(0);
@@ -354,7 +359,7 @@ describe("Bond", () => {
             );
           });
           it("should withdraw excess payment when bonds are converted", async () => {
-            const halfBonds = (await bond.balanceOf(owner.address)).div(2);
+            const halfBonds = (await bond.balanceOf(bond.address)).div(2);
             const fullPayment = await bond.amountUnpaid();
             await paymentToken.transfer(bond.address, fullPayment);
             expect(await bond.previewWithdrawExcessPayment()).to.equal(0);
@@ -1116,6 +1121,52 @@ describe("Bond", () => {
             await expect(
               bond.connect(bondHolder).burn(config.maxSupply)
             ).to.be.revertedWith("Ownable: caller is not the owner");
+          });
+        });
+      });
+      describe.only("purchase", async () => {
+        describe("non convertible", async () => {
+          beforeEach(async () => {
+            bond = bondWithTokens.nonConvertible.bond;
+            config = bondWithTokens.nonConvertible.config;
+            await paymentToken.transfer(
+              bondBuyer.address,
+              ethers.constants.Two
+            );
+          });
+
+          it("fails when trying to purchase with unapproved paymentToken amount", async () => {
+            await expect(
+              bond.connect(bondBuyer).purchaseBond(ethers.constants.One)
+            ).to.be.revertedWith("NotEnoughPaymentTokenAllowed");
+          });
+
+          it("should transfer the paymentToken to the contract owner", async () => {
+            await paymentToken
+              .connect(bondBuyer)
+              .approve(bond.address, ethers.constants.Two);
+
+            const bondOwnerBalance = await paymentToken.balanceOf(
+              owner.address
+            );
+            await bond.connect(bondBuyer).purchaseBond(ethers.constants.One); // Just buying 1
+            const bondOwnerNewBalance = await paymentToken.balanceOf(
+              owner.address
+            );
+
+            expect(bondOwnerNewBalance).to.gt(bondOwnerBalance);
+          });
+
+          it("should transfer the bond to the buyer", async () => {
+            await paymentToken
+              .connect(bondBuyer)
+              .approve(bond.address, ethers.constants.Two);
+
+            await bond.connect(bondBuyer).purchaseBond(ethers.constants.One); // Just buying 1
+
+            expect(await bond.balanceOf(bondBuyer.address)).to.eq(
+              ethers.constants.One
+            );
           });
         });
       });

--- a/test/BondFactory.spec.ts
+++ b/test/BondFactory.spec.ts
@@ -80,7 +80,8 @@ describe("BondFactory", async () => {
       testCollateralToken,
       testCollateralTokenAmount,
       testConvertibleTokenAmount,
-      testMaxSupply
+      testMaxSupply,
+      "Uniswap"
     );
   }
 


### PR DESCRIPTION
- Changed mint to point to the contract address instead of owner. This allows:
  - balanceOf() to be used as a bonds remaining. 
  - This allows purchases to be made directly from the contract.
-  Add purchaseBond method
-  Added specs